### PR TITLE
Adapt for SOCKMAP and builds against system kernel packages

### DIFF
--- a/ebpf/inet-kern-shared.c
+++ b/ebpf/inet-kern-shared.c
@@ -1,8 +1,8 @@
 struct bpf_map_def SEC("maps") redir_map = {
-	.type = BPF_MAP_TYPE_REUSEPORT_SOCKARRAY,
+	.type = BPF_MAP_TYPE_SOCKMAP,
 	.max_entries = 512,
 	.key_size = sizeof(uint32_t),
-	.value_size = sizeof(uint64_t),
+	.value_size = sizeof(uint32_t),
 };
 
 struct bpf_map_def SEC("maps") bind_map = {

--- a/ebpf/inet-kern-shared.c
+++ b/ebpf/inet-kern-shared.c
@@ -1,8 +1,8 @@
 struct bpf_map_def SEC("maps") redir_map = {
 	.type = BPF_MAP_TYPE_SOCKMAP,
 	.max_entries = 512,
-	.key_size = sizeof(uint32_t),
-	.value_size = sizeof(uint32_t),
+	.key_size = sizeof(__u32),
+	.value_size = sizeof(__u32),
 };
 
 struct bpf_map_def SEC("maps") bind_map = {
@@ -17,6 +17,6 @@ struct bpf_map_def SEC("maps") srvname_map = {
 	.type = BPF_MAP_TYPE_HASH,
 	.max_entries = 512,
 	.key_size = sizeof(struct srvname),
-	.value_size = sizeof(uint32_t),
+	.value_size = sizeof(__u32),
 	.map_flags = BPF_F_NO_PREALLOC,
 };

--- a/ebpf/inet-kern-shared.h
+++ b/ebpf/inet-kern-shared.h
@@ -1,9 +1,11 @@
+#include <linux/types.h>
+
 struct addr {
-	uint32_t prefixlen;
-	uint8_t protocol;
-	uint16_t port;
+	__u32 prefixlen;
+	__u8 protocol;
+	__u16 port;
 	struct ip {
-		uint32_t ip_as_w[4];
+		__u32 ip_as_w[4];
 	} addr;
 };
 

--- a/ebpf/inet-kern.c
+++ b/ebpf/inet-kern.c
@@ -1,5 +1,4 @@
-#include <stdint.h>
-#include <stdio.h>
+#include <stddef.h>
 #include <sys/socket.h>
 
 #include <linux/bpf.h>
@@ -17,8 +16,8 @@ int _inet_program(struct bpf_inet_lookup *ctx)
 {
 	/* Force 32 bit loads from context, to avoid eBPF "ctx modified"
 	 * messages */
-	volatile uint32_t protocol = ctx->protocol;
-	volatile uint32_t local_port = ctx->local_port;
+	volatile __u32 protocol = ctx->protocol;
+	volatile __u32 local_port = ctx->local_port;
 
 	/* /32 and /128 */
 	struct ip laddr_full = {};
@@ -64,7 +63,7 @@ int _inet_program(struct bpf_inet_lookup *ctx)
 		srvname =
 			(struct srvname *)bpf_map_lookup_elem(&bind_map, &key);
 		if (srvname != NULL) {
-			uint32_t *index = (uint32_t *)bpf_map_lookup_elem(
+			__u32 *index = (__u32 *)bpf_map_lookup_elem(
 				&srvname_map, srvname);
 			if (index != NULL) {
 				int r = bpf_redirect_lookup(ctx, &redir_map,

--- a/ebpf/inet-kern.c
+++ b/ebpf/inet-kern.c
@@ -1,10 +1,10 @@
-#include "linux_bpf.h"
 #include <stdint.h>
 #include <stdio.h>
 #include <sys/socket.h>
 
-#include "bpf_endian.h"
-#include "bpf_helpers.h"
+#include <linux/bpf.h>
+#include <bpf/bpf_endian.h>
+#include <bpf/bpf_helpers.h>
 
 #include "inet-kern-shared.h"
 

--- a/src/inet-commands.c
+++ b/src/inet-commands.c
@@ -10,9 +10,9 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#include "libbpf.h"
-#include "libbpf_ebpf.h"
-#include "linux_bpf.h"
+#include <linux/bpf.h>
+#include <bpf/bpf.h>
+#include <bpf/libbpf.h>
 
 #include "../ebpf/inet-kern-shared.h"
 #include "inet.h"

--- a/src/inet-scm.c
+++ b/src/inet-scm.c
@@ -11,8 +11,8 @@
 #include <sys/un.h>
 #include <unistd.h>
 
-#include "libbpf_ebpf.h"
-#include "linux_bpf.h"
+#include <linux/bpf.h>
+#include <bpf/bpf.h>
 
 #include "inet.h"
 


### PR DESCRIPTION
This series tweaks the build script so that we can compile the tool against a kernel source tree as well as system packages containing Linux and libbpf headers.

Before building the `inet-tool` kernel source tree needs to be prepared by generating UAPI headers (`make headers_install`) and building libbpf. Kernel source tree will be used only if `KERNEL_DIR` variable is set.

Otherwise we fall back to using headers from system packages. On Debian they will be available in `linux-libc-dev` and `libbpf-dev` packages.

Second part of PR switches the redirect map from `REUSEPORT_SOCKARRAY` to `SOCKMAP` to follow the [recent kernel-side work](https://github.com/jsitnicki/linux/commits/bpf-inet-lookup-sockmap).

We also switch away from integer types which are not available to BPF C code due to lack of architecture specific headers.