### PR TITLE
Various fixes needed for the lab test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CLANG      ?= clang
 KERNEL_DIR ?=
 
 HOST_ARCH = $(shell uname -m)-linux-gnu
+LIBC_INC_DIR = /usr/include/$(HOST_ARCH)
 
 ifeq ($(KERNEL_DIR),)
 # Build against system packages.
@@ -47,7 +48,7 @@ DEPS_H = \
 	$(LIBBPF_INC_DIR)/bpf/bpf_helpers.h
 
 DEPS     = $(LIBBPF_LIB_DIR)/libbpf.a $(DEPS_H)
-INCLUDES = -I$(LINUX_INC_DIR) -I$(LIBBPF_INC_DIR)
+INCLUDES = -I$(LIBC_INC_DIR) -I$(LINUX_INC_DIR) -I$(LIBBPF_INC_DIR)
 
 INET_TOOL_DEPS=src/*.[ch] $(DEPS) inet-ebpf.c Makefile ebpf/*shared*
 

--- a/ebpf/inet-kern-shared.h
+++ b/ebpf/inet-kern-shared.h
@@ -9,8 +9,9 @@ struct addr {
 	} addr;
 };
 
+/* FD names passed by systemd can be 255 characters long. Match the limit. */
 struct srvname {
-	char name[32];
+	char name[255];
 };
 
 enum { REDIR_MAP,

--- a/src/inet-commands.c
+++ b/src/inet-commands.c
@@ -426,11 +426,6 @@ void inet_register(struct state *state, char **fdnames, char **srvnames)
 
 			int r = inet_register_socket(state, fd, name);
 			if (r == -1) {
-				fprintf(stderr,
-					"[!] Socket must have SO_REUSEPORT "
-					"set!\n");
-			}
-			if (r == -2) {
 				fprintf(stderr, "[!] redir_map full!\n");
 			}
 
@@ -470,15 +465,6 @@ void inet_unregister(struct state *state, char *service)
 
 int inet_register_socket(struct state *state, int fd, char *fdname)
 {
-	if (fd >= 0) {
-		int o = 0;
-		socklen_t l = sizeof(int);
-		getsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &o, &l);
-		if (o != 1) {
-			return -1;
-		}
-	}
-
 	struct srvname srvname = {};
 	strncpy(srvname.name, fdname, sizeof(srvname.name));
 
@@ -530,7 +516,7 @@ int inet_register_socket(struct state *state, int fd, char *fdname)
 	}
 
 	if (redir_index == UINT_MAX) {
-		return -2;
+		return -1;
 	}
 
 	if (fd >= 0) {

--- a/src/inet-scm.c
+++ b/src/inet-scm.c
@@ -155,10 +155,6 @@ void inet_scm_serve(struct state *state)
 
 		r = inet_register_socket(state, fd, fdname);
 		if (r == -1) {
-			fprintf(stderr,
-				"[!] Socket must have SO_REUSEPORT set!\n");
-		}
-		if (r == -2) {
 			fprintf(stderr, "[!] redir_map full!\n");
 		}
 		close(fd);


### PR DESCRIPTION
- don't demand that sockets have `SO_REUSEPORT` set
- don't truncate service names when inheriting sockets from systemd
- fix build on Debian