### PR TITLE
Expand README instructions for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@ The tool to manage INET_LOOKUP program.
 
 Dependencies:
 
-    apt install python3-virtualenv build-essential clang clang-format lcov
+    apt install \
+        build-essential \
+        clang \
+        clang-format \
+        lcov \
+        libc6-dev-i386 \
+        libz-dev \
+        python3-virtualenv \
+        virtualenv
 
 Clang is needed to compile C into the eBPF program.
 
@@ -14,15 +22,12 @@ First, you need to run experimental kernel with INET_LOOKUP
 patches. For example:
 
     cd /tmp
-    git clone https://github.com/jsitnicki/linux.git --branch bpf-inet-lookup --depth 1000
+    git clone https://github.com/jsitnicki/linux.git --branch bpf-inet-lookup --depth 1
 
 Then you can build the `inet-tool`:
 
+    (cd /tmp/linux && make headers_install && make -C tools/lib/bpf)
     make KERNEL_DIR=/tmp/linux
-
-To build:
-
-    make
 
 Tu run tests (requires root):
 


### PR DESCRIPTION
- Some dependencies were missing from the list.
- We don't need any Git history for building.
- We need to prepare the kernel tree before building.

Details on how to build the kernel and run tests with help of virme
or UML are still missing. Flushing out what I have already tested.