### PR TITLE
Convert to link-based SK_LOOKUP program attachment

### DIFF
--- a/src/inet-commands.c
+++ b/src/inet-commands.c
@@ -298,24 +298,8 @@ int inet_prog_verify()
 int inet_unload(struct state *state)
 {
 	int return_code = 0;
-	int fd = open("/proc/self/ns/net", O_RDONLY);
-	if (fd < 0) {
-		PFATAL("open(/proc/self/ns/net)");
-	}
 
-	uint32_t attach_flags = 0;
-	uint32_t prog_ids[1] = {0};
-	uint32_t prog_cnt = 1;
-
-	int r = bpf_prog_query(fd, BPF_SK_LOOKUP, 0, &attach_flags, prog_ids,
-			       &prog_cnt);
-	if (r) {
-		PFATAL("bpf(PROG_QUERY, BPF_SK_LOOKUP)");
-	}
-	close(fd);
-
-	// BPF_F_ALLOW_OVERRIDE doesn't work
-	r = bpf_prog_detach2(0, 0, BPF_SK_LOOKUP);
+	int r = bpf_prog_detach2(0, 0, BPF_SK_LOOKUP);
 	if (r == 0) {
 		printf("[+] SK_LOOKUP program unloaded\n");
 	} else {

--- a/src/inet-commands.c
+++ b/src/inet-commands.c
@@ -57,7 +57,7 @@ void inet_load(struct state *state)
 		struct bpf_map_def *def = ebpf_maps[map_pos];
 		char map_name[PATH_MAX];
 		snprintf(map_name, sizeof(map_name), "%s%s",
-			 state->sys_fs_map_prefix, ebpf_maps_names[map_pos]);
+			 state->sys_fs_obj_prefix, ebpf_maps_names[map_pos]);
 
 		int map_fd = state->map_fds[map_pos];
 		if (map_fd == 0) {
@@ -146,7 +146,7 @@ void inet_open_verify_maps(struct state *state, int all_needed)
 		struct bpf_map_def *def = ebpf_maps[map_pos];
 		char map_name[PATH_MAX];
 		snprintf(map_name, sizeof(map_name), "%s%s",
-			 state->sys_fs_map_prefix, ebpf_maps_names[map_pos]);
+			 state->sys_fs_obj_prefix, ebpf_maps_names[map_pos]);
 
 		/* 1. try to reuse already opened maps */
 		int map_fd = state->map_fds[map_pos];
@@ -311,7 +311,7 @@ int inet_unload(struct state *state)
 	for (map_pos = 0; map_pos < ebpf_maps_sz; map_pos++) {
 		char map_name[PATH_MAX];
 		snprintf(map_name, sizeof(map_name), "%s%s",
-			 state->sys_fs_map_prefix, ebpf_maps_names[map_pos]);
+			 state->sys_fs_obj_prefix, ebpf_maps_names[map_pos]);
 
 		r = unlink(map_name);
 		if (r == 0) {

--- a/src/inet-commands.c
+++ b/src/inet-commands.c
@@ -6,6 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -33,6 +34,8 @@ char *ebpf_maps_names[] = {
 	"bind_map",
 	"srvname_map",
 };
+
+const char *ebpf_link_name = "sk_lookup_link";
 
 extern size_t bpf_insn_sk_lookup_cnt;
 extern struct bpf_insn bpf_insn_sk_lookup[];
@@ -120,21 +123,42 @@ void inet_load(struct state *state)
 		PFATAL("Bpf Log:\n%s\n bpf(BPF_PROG_LOAD)", log_buf);
 	}
 
-	int r = bpf_prog_attach(bpf_prog, 0, BPF_SK_LOOKUP, 0);
-	if (r) {
-		if (errno == EEXIST) {
-			fprintf(stderr,
-				"[-] Unloading previous SK_LOOKUP "
-				"program\n");
-			// BPF_F_ALLOW_OVERRIDE doesn't work
-			bpf_prog_detach2(0, 0, BPF_SK_LOOKUP);
+	/* link create/update */
+	char link_name[PATH_MAX];
+	snprintf(link_name, sizeof(link_name), "%s%s",
+		 state->sys_fs_obj_prefix, ebpf_link_name);
 
-			/* Try again */
-			r = bpf_prog_attach(bpf_prog, 0, BPF_SK_LOOKUP, 0);
+	if (state->link_fd < 0) {
+		/* link doesn't exist, create it */
+		int netns_fd = open("/proc/self/ns/net", O_RDONLY);
+		if (netns_fd < 0) {
+			PFATAL("open(/proc/self/ns/net)");
 		}
+
+		DECLARE_LIBBPF_OPTS(bpf_link_create_opts, opts);
+		int link_fd = bpf_link_create(bpf_prog, netns_fd, BPF_SK_LOOKUP, &opts);
+		if (link_fd < 0) {
+			PFATAL("bpf_link_create(BPF_SK_LOOKUP)");
+		}
+
+		int r = bpf_obj_pin(link_fd, link_name);
 		if (r) {
-			PFATAL("bpf(BPF_ATTACH, BPF_SK_LOOKUP)");
+			PFATAL("bpf_obj_pin(%s)", link_name);
 		}
+
+		state->link_fd = link_fd;
+		close(netns_fd);
+
+		fprintf(stderr, "[+] Created link %s\n", link_name);
+	} else {
+		/* link already exists, update it */
+		DECLARE_LIBBPF_OPTS(bpf_link_update_opts, opts);
+		int r = bpf_link_update(state->link_fd, bpf_prog, &opts);
+		if (r) {
+			PFATAL("bpf_link_update");
+		}
+
+		fprintf(stderr, "[+] Updated link %s\n", link_name);
 	}
 	printf("SK_LOOKUP program loaded\n");
 }
@@ -194,6 +218,50 @@ void inet_open_verify_maps(struct state *state, int all_needed)
 		}
 		state->map_fds[map_pos] = map_fd;
 	}
+}
+
+void inet_open_verify_link(struct state *state)
+{
+	char link_name[PATH_MAX];
+	snprintf(link_name, sizeof(link_name), "%s%s",
+		 state->sys_fs_obj_prefix, ebpf_link_name);
+
+	/* 1. try to open pinned link */
+	int link_fd = bpf_obj_get(link_name);
+
+	/* 2. ignore if link doesn't exist, will create it on "load",
+	 *    fail otherwise */
+	if (link_fd < 0) {
+		if (errno == ENOENT) {
+			link_fd = -1;
+			goto out;
+		}
+		PFATAL("bpf_obj_get(%s)", link_name);
+	}
+
+	struct stat st;
+	int r = stat("/proc/self/ns/net", &st);
+	if (r < 0) {
+		PFATAL("stat(/proc/self/ns/net)");
+	}
+
+	/* 3. verify existing link info */
+	struct bpf_link_info info = {};
+	uint32_t info_sz = sizeof(struct bpf_link_info);
+	r = bpf_obj_get_info_by_fd(link_fd, &info, &info_sz);
+
+	if (info.type != BPF_LINK_TYPE_NETNS ||
+	    info.netns.attach_type != BPF_SK_LOOKUP ||
+	    info.netns.netns_ino != st.st_ino ||
+	    !info.id || !info.prog_id) {
+		fprintf(stderr,
+			"[!] Link %s info is not as expected."
+			"Remove the link file first\n",
+			link_name);
+		exit(-1);
+	}
+out:
+	state->link_fd = link_fd;
 }
 
 struct prog_info {
@@ -299,14 +367,19 @@ int inet_unload(struct state *state)
 {
 	int return_code = 0;
 
-	int r = bpf_prog_detach2(0, 0, BPF_SK_LOOKUP);
+	char link_name[PATH_MAX];
+	snprintf(link_name, sizeof(link_name), "%s%s",
+		 state->sys_fs_obj_prefix, ebpf_link_name);
+
+	int r = unlink(link_name);
 	if (r == 0) {
-		printf("[+] SK_LOOKUP program unloaded\n");
+		printf("[+] Unpinned SK_LOOKUP link %s\n", link_name);
 	} else {
-		printf("[-] Failed to unload SK_LOOKUP: %s\n",
+		printf("[-] Failed to unpin SK_LOOKUP link %s: %s\n", link_name,
 		       strerror(errno));
-		return_code = 1;
+		return_code = errno;
 	}
+
 	int map_pos;
 	for (map_pos = 0; map_pos < ebpf_maps_sz; map_pos++) {
 		char map_name[PATH_MAX];
@@ -317,7 +390,7 @@ int inet_unload(struct state *state)
 		if (r == 0) {
 			printf("[+] Unpinned map %s\n", map_name);
 		} else {
-			printf("[-] Failed to unlink map %s: %s\n", map_name,
+			printf("[-] Failed to unpin map %s: %s\n", map_name,
 			       strerror(errno));
 		}
 	}

--- a/src/inet.h
+++ b/src/inet.h
@@ -16,7 +16,7 @@
 /* inet-tool.c */
 struct state {
 	char sys_fs_obj_prefix[256];
-
+	int link_fd;
 	int map_fds[128];
 
 	char *unix_path;
@@ -34,6 +34,7 @@ int inet_unload(struct state *state);
 int inet_prog_info(struct state *state);
 int inet_prog_verify(void);
 void inet_open_verify_maps(struct state *state, int all_needed);
+void inet_open_verify_link(struct state *state);
 
 void inet_list(struct state *state);
 void inet_register(struct state *state, char **fdnames, char **srvnames);

--- a/src/inet.h
+++ b/src/inet.h
@@ -15,7 +15,7 @@
 
 /* inet-tool.c */
 struct state {
-	char sys_fs_map_prefix[256];
+	char sys_fs_obj_prefix[256];
 
 	int map_fds[128];
 

--- a/src/main.c
+++ b/src/main.c
@@ -55,7 +55,7 @@ int main(int argc, char *argv[])
 		PFATAL("open(/proc/self/ns/net)");
 	}
 
-	snprintf(state->sys_fs_map_prefix, sizeof(state->sys_fs_map_prefix),
+	snprintf(state->sys_fs_obj_prefix, sizeof(state->sys_fs_obj_prefix),
 		 "/sys/fs/bpf/%lu_", net_ns_inode);
 
 	bump_memlimit();

--- a/src/main.c
+++ b/src/main.c
@@ -164,6 +164,7 @@ int main(int argc, char *argv[])
 	}
 
 	inet_open_verify_maps(state, 0);
+	inet_open_verify_link(state);
 
 	if (command == CMD_LOAD) {
 		inet_load(state);

--- a/tests/base.py
+++ b/tests/base.py
@@ -14,6 +14,7 @@ INETTOOLBIN = os.environ.get('INETTOOLBIN')
 IP_FREEBIND = 15
 CLONE_NEWNET = 0x40000000
 original_net_ns = open("/proc/self/ns/net", 'rb')
+SOCKET_TIMEOUT = 5 # seconds
 
 HELLO_WORLD_SERVER='./tools/hello-world-server.py'
 
@@ -132,7 +133,7 @@ class TestCase(unittest.TestCase):
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         else:
             s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-        s.settimeout(2)
+        s.settimeout(SOCKET_TIMEOUT)
 
         with self.assertRaises(socket.error) as e:
             s.connect((ip, port))
@@ -144,7 +145,7 @@ class TestCase(unittest.TestCase):
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         else:
             s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-        s.settimeout(2)
+        s.settimeout(SOCKET_TIMEOUT)
 
         s.connect((ip, port))
         s.close()
@@ -154,7 +155,7 @@ class TestCase(unittest.TestCase):
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         else:
             s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
-        s.settimeout(2)
+        s.settimeout(SOCKET_TIMEOUT)
 
         s.connect((ip, port))
         data = s.recv(2048)
@@ -184,7 +185,7 @@ def bind_tcp(ip='127.0.0.1', port=0, cloexec=True, reuseaddr=True, reuseport=Tru
     else:
         s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
 
-    s.settimeout(2)
+    s.settimeout(SOCKET_TIMEOUT)
 
     if cleanup:
         RUN_CMD_BUFFER.append(("bind_tcp", s))

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -220,7 +220,7 @@ class BasicTest(base.TestCase):
         base.inet_tool('unbind 6 [8000:]/1:0').close()
 
 
-    def test_basic_tcp_regiser(self):
+    def test_basic_tcp_register(self):
         ''' Verify if register and command work '''
         base.inet_tool('load').close()
         base.inet_tool('bind 6 127.0.0.1:1234 x').close()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,5 @@
 from . import base
+import errno
 
 
 class BasicTest(base.TestCase):
@@ -46,7 +47,7 @@ class BasicTest(base.TestCase):
         self.assertEqual(rc, 0)
 
         p = base.inet_tool('unload')
-        self.assertIn("SK_LOOKUP program unloaded", p.stdout_line())
+        self.assertIn("Unpinned SK_LOOKUP link", p.stdout_line())
         rc = p.close()
         self.assertEqual(rc, 0)
 
@@ -56,9 +57,9 @@ class BasicTest(base.TestCase):
         self.assertEqual(rc, 1)
 
         p = base.inet_tool('unload')
-        self.assertIn("Failed to unload SK_LOOKUP: No such", p.stdout_line())
+        self.assertIn("Failed to unpin SK_LOOKUP link", p.stdout_line())
         rc = p.close()
-        self.assertEqual(rc, 1)
+        self.assertEqual(rc, errno.ENOENT)
 
 
     def test_basic_tcp_bind(self):


### PR DESCRIPTION
v3 iteration of SK_LOOKUP patches uses link-based program attachment. The old way of attaching BPF programs directly is no longer supported.

Extend the initialization code to discover pinned link to attached program. Convert "load" handler to create a link and pin it if it doesn't exist, or update the existing link. And finally, modify "unload" handler to detach the program by unpinning the link.
